### PR TITLE
Input output

### DIFF
--- a/configure_deployer.yml
+++ b/configure_deployer.yml
@@ -4,4 +4,5 @@
 
   roles:
     - conf/web
+    - conf/outputs
     - conf/server

--- a/configure_deploymentserver.yml
+++ b/configure_deploymentserver.yml
@@ -4,4 +4,5 @@
 
   roles:
     - conf/web
+    - conf/outputs
     - conf/server

--- a/configure_dmc.yml
+++ b/configure_dmc.yml
@@ -4,6 +4,7 @@
 
   roles:
     - conf/web
+    - conf/outputs
     - conf/server
     - conf/distsearch
     - group/searchhead

--- a/configure_licensemaster.yml
+++ b/configure_licensemaster.yml
@@ -4,5 +4,6 @@
 
   roles:
     - conf/web
+    - conf/outputs
     - conf/server
     - group/licensemaster

--- a/configure_masternode.yml
+++ b/configure_masternode.yml
@@ -4,4 +4,5 @@
 
   roles:
     - conf/web
+    - conf/outputs
     - conf/server

--- a/configure_searchhead.yml
+++ b/configure_searchhead.yml
@@ -5,4 +5,5 @@
   roles:
     - group/searchhead
     - conf/web
+    - conf/outputs
     - conf/server

--- a/configure_shcmember.yml
+++ b/configure_shcmember.yml
@@ -4,4 +4,5 @@
 
   roles:
     - conf/web
+    - conf/outputs
     - conf/server

--- a/install_shcmember.yml
+++ b/install_shcmember.yml
@@ -4,6 +4,7 @@
 
   roles:
     - conf/web
+    - conf/outputs
     - conf/server
     - group/shcmember
     - conf/server

--- a/roles/conf/outputs/tasks/indexAndForward.yml
+++ b/roles/conf/outputs/tasks/indexAndForward.yml
@@ -1,0 +1,16 @@
+- name: "Configure outputs.conf [indexAndForward] - index state=present"
+  ini_file: dest={{ splunk_conf_path }}/outputs.conf
+            section=indexAndForward
+            option=index
+            value={{ splunk_outputs_conf.indexAndForward.index }}
+            state=present
+  when: splunk_outputs_conf.indexAndForward.index is defined
+  notify: splunk restart
+
+- name: "Configure outputs.conf [indexAndForward] - index state=absent (default)"
+  ini_file: dest={{ splunk_conf_path }}/outputs.conf
+            section=indexAndForward
+            option=index
+            state=absent
+  when: splunk_outputs_conf.indexAndForward.index is undefined
+  notify: splunk restart

--- a/roles/conf/outputs/tasks/main.yml
+++ b/roles/conf/outputs/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - include: touch.yml
 - include: tcpout/defaultGroup.yml
+- include: tcpout/indexAndForward.yml
 - include: tcpout:target_group/indexerDiscovery.yml
 - include: tcpout:target_group/server.yml
 - include: tcpout:target_group/sslCertPath.yml
@@ -8,5 +9,6 @@
 - include: tcpout:target_group/sslRootCAPath.yml
 - include: tcpout:target_group/sslVerifyServerCert.yml
 - include: tcpout:target_group/useAck.yml
+- include: indexAndForward.yml
 - include: indexer_discovery/pass4SymmKey.yml
 - include: indexer_discovery/master_uri.yml

--- a/roles/conf/outputs/tasks/tcpout/indexAndForward.yml
+++ b/roles/conf/outputs/tasks/tcpout/indexAndForward.yml
@@ -1,0 +1,16 @@
+- name: "Configure outputs.conf [tcpout] - indexAndForward state=present"
+  ini_file: dest={{ splunk_conf_path }}/outputs.conf
+            section=tcpout
+            option=indexAndForward
+            value={{ splunk_outputs_conf.tcpout.indexAndForward }}
+            state=present
+  when: splunk_outputs_conf.tcpout.indexAndForward is defined
+  notify: splunk restart
+
+- name: "Configure outputs.conf [tcpout] - indexAndForward state=absent (default)"
+  ini_file: dest={{ splunk_conf_path }}/outputs.conf
+            section=tcpout
+            option=indexAndForward
+            state=absent
+  when: splunk_outputs_conf.tcpout.indexAndForward is undefined
+  notify: splunk restart

--- a/roles/conf/server/tasks/shclustering/id.yml
+++ b/roles/conf/server/tasks/shclustering/id.yml
@@ -17,11 +17,3 @@
             state=present
   when: splunk_server_conf.shclustering.id is defined
   notify: splunk restart
-
-- name: "Configure server.conf [shclustering] - id state=absent"
-  ini_file: dest={{ splunk_conf_path }}/server.conf
-            section=shclustering
-            option=id
-            state=absent
-  when: splunk_server_conf.shclustering.id is undefined
-  notify: splunk restart


### PR DESCRIPTION
forwards _internal index data to indexers
removed task for disabling shcluster ID, as splunk supplies the ID and we don't want Ansible to comment it out
