### PR TITLE
include role/conf/server/clustering/pass4SymmKey

### DIFF
--- a/roles/conf/server/tasks/main.yml
+++ b/roles/conf/server/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - include: touch.yml
+- include: clustering/pass4SymmKey.yml
 - include: clustering/available_sites.yml
 - include: clustering/cluster_label.yml
 - include: clustering/master_uri.yml


### PR DESCRIPTION
why was this not here already? :( 
(corresponds with branch splunk-groupvars-stage/clustering-pass4symmkey)
