### PR TITLE
Lm distsearch

### DIFF
--- a/roles/group/licensemaster/tasks/distsearch.yml
+++ b/roles/group/licensemaster/tasks/distsearch.yml
@@ -1,0 +1,17 @@
+---
+- name: "Configure distsearch.conf [distributedSearch] state=present"
+  ini_file: dest={{ splunk_conf_path }}/distsearch.conf
+            section="distributedSearch"
+            option=servers
+            value="{{ groups['masternode'] | create_distsearch_servers }}"
+            state=present
+  when: groups['masternode'] is defined
+  notify: splunk restart
+
+- name: "Configure distsearch.conf [distributedSearch] state=absent (default)"
+  ini_file: dest={{ splunk_conf_path }}/distsearch.conf
+            section="distributedSearch"
+            option=servers
+            state=absent
+  when: groups['masternode'] is undefined
+  notify: splunk restart

--- a/roles/group/licensemaster/tasks/main.yml
+++ b/roles/group/licensemaster/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: copy_enterprise_license_keys.yml
-  when: {{ osu_environment }} == "prod"
+  when: "{{ osu_environment }} == 'prod'"
 
 - include: touch.yml
 - include: distsearch.yml

--- a/roles/group/licensemaster/tasks/main.yml
+++ b/roles/group/licensemaster/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: copy_enterprise_license_keys.yml
-  when: "{{ osu_environment }} == 'prod'"
+  when: osu_environment == "prod"
 
 - include: touch.yml
 - include: distsearch.yml

--- a/roles/group/licensemaster/tasks/main.yml
+++ b/roles/group/licensemaster/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
 - include: copy_enterprise_license_keys.yml
+  when: {{ osu_environment }} == "prod"
+
 - include: touch.yml
 - include: distsearch.yml

--- a/roles/group/licensemaster/tasks/main.yml
+++ b/roles/group/licensemaster/tasks/main.yml
@@ -1,2 +1,4 @@
 ---
 - include: copy_enterprise_license_keys.yml
+- include: touch.yml
+- include: distsearch.yml

--- a/roles/group/licensemaster/tasks/touch.yml
+++ b/roles/group/licensemaster/tasks/touch.yml
@@ -1,0 +1,8 @@
+---
+- name: "Touch distsearch.conf"
+  file: path={{ splunk_conf_path }}/distsearch.conf
+        owner=splunk
+        group=splunk
+        mode=600
+        state=touch
+  changed_when: false


### PR DESCRIPTION
Licensemaster needs to enable the index cluster master as a search peer, so it may retrieve log information > 1 day. This is separate from the roles/conf/distsearch role, as this shouldn't be run on other servers (dmc) and regular distsearch role shouldn't be ran on the LM. 
